### PR TITLE
データ取得時のページング処理を修正

### DIFF
--- a/lang/ja/class.php
+++ b/lang/ja/class.php
@@ -31,4 +31,5 @@ return [
     \HaruyaNishikubo\Transporter\Models\Node\Source\Repository\Shopify\Rest\CollectRepository::class => 'shopify.collect',
     \HaruyaNishikubo\Transporter\Models\Node\Source\Repository\Shopify\Rest\CollectionRepository::class => 'shopify.collection',
     \HaruyaNishikubo\Transporter\Models\Node\Source\Repository\Shopify\Rest\RefundRepository::class => 'shopify.refund',
+    \HaruyaNishikubo\Transporter\Models\Node\Source\Repository\Shopify\Rest\TransactionRepository::class => 'shopify.transaction',
 ];

--- a/resources/views/connector_task/show.blade.php
+++ b/resources/views/connector_task/show.blade.php
@@ -41,6 +41,7 @@
                 <table class="table-auto w-full">
                     <thead>
                     <tr>
+                        <x-transporter::tables.th>{{ __('transporter::models.connector_task_line.field.id') }}</x-transporter::tables.th>
                         <x-transporter::tables.th>{{ __('transporter::models.connector_task_line.field.source_repository') }}</x-transporter::tables.th>
                         <x-transporter::tables.th>{{ __('transporter::models.connector_task_line.field.target_repository') }}</x-transporter::tables.th>
                         <x-transporter::tables.th>{{ __('transporter::models.connector_task_line.field.status') }}</x-transporter::tables.th>
@@ -50,6 +51,7 @@
                     <tbody>
                     @foreach($connector_task_lines as $connector_task_line)
                         <tr>
+                            <x-transporter::tables.td>{{ $connector_task_line->id }}</x-transporter::tables.td>
                             <x-transporter::tables.td>{{ __(sprintf('transporter::class.%s', $connector_task_line->source_repository)) }}</x-transporter::tables.td>
                             <x-transporter::tables.td>{{ __(sprintf('transporter::class.%s', $connector_task_line->target_repository)) }}</x-transporter::tables.td>
                             <x-transporter::tables.td>{{ $connector_task_line->status }}</x-transporter::tables.td>

--- a/src/Console/Commands/ConnectorTaskLineRunnerCommand.php
+++ b/src/Console/Commands/ConnectorTaskLineRunnerCommand.php
@@ -210,12 +210,6 @@ class ConnectorTaskLineRunnerCommand extends Command
     protected function extract(): self
     {
         $this->source_repository
-            ->setStartCursor($this->connector_task_line
-                ->connectorTask
-                ->start_cursor_at)
-            ->setEndCursor($this->connector_task_line
-                ->connectorTask
-                ->end_cursor_at)
             ->prepare()
             ->extract();
 

--- a/src/Console/Commands/ConnectorTaskLineRunnerCommand.php
+++ b/src/Console/Commands/ConnectorTaskLineRunnerCommand.php
@@ -192,9 +192,6 @@ class ConnectorTaskLineRunnerCommand extends Command
         $this->source_repository = $this->connector_task_line
             ->buildSourceRepository();
 
-        $this->source_repository
-            ->setAttributes($this->connector_task_line->source_repository_attributes ?? []);
-
         return $this;
     }
 

--- a/src/Console/Commands/ConnectorTaskLineRunnerCommand.php
+++ b/src/Console/Commands/ConnectorTaskLineRunnerCommand.php
@@ -92,8 +92,8 @@ class ConnectorTaskLineRunnerCommand extends Command
                 ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
             }
 
-            if ($this->source_repository->hasNextQueries()) {
-                $this->registerConnectorTaskLineOfNext($this->source_repository->nextQueries());
+            if ($this->source_repository->hasNextPage()) {
+                $this->registerConnectorTaskLineOfNext($this->source_repository->nextPageQuery());
             }
 
             if ($this->hasSubset()) {

--- a/src/Console/Commands/ConnectorTaskLineRunnerCommand.php
+++ b/src/Console/Commands/ConnectorTaskLineRunnerCommand.php
@@ -93,7 +93,7 @@ class ConnectorTaskLineRunnerCommand extends Command
             }
 
             if ($this->source_repository->hasNextPage()) {
-                $this->registerConnectorTaskLineOfNext($this->source_repository->nextPageQuery());
+                $this->registerConnectorTaskLineOfNextPage($this->source_repository->nextPageQuery());
             }
 
             if ($this->hasSubset()) {
@@ -232,10 +232,10 @@ class ConnectorTaskLineRunnerCommand extends Command
         return $this;
     }
 
-    protected function registerConnectorTaskLineOfNext(array $next_queries): self
+    protected function registerConnectorTaskLineOfNextPage(array $next_page_query): self
     {
         $this->createConnectorTaskLine($this->connector_task_line->source_repository, [
-            'query' => $next_queries,
+            'query' => $next_page_query,
         ]);
 
         return $this;

--- a/src/Console/Commands/ConnectorTaskLineRunnerCommand.php
+++ b/src/Console/Commands/ConnectorTaskLineRunnerCommand.php
@@ -240,7 +240,9 @@ class ConnectorTaskLineRunnerCommand extends Command
 
     protected function registerConnectorTaskLineOfNext(array $next_queries): self
     {
-        $this->createConnectorTaskLine($this->connector_task_line->source_repository, $next_queries);
+        $this->createConnectorTaskLine($this->connector_task_line->source_repository, [
+            'query' => $next_queries,
+        ]);
 
         return $this;
     }

--- a/src/Console/Commands/ConnectorTaskLineRunnerCommand.php
+++ b/src/Console/Commands/ConnectorTaskLineRunnerCommand.php
@@ -96,7 +96,7 @@ class ConnectorTaskLineRunnerCommand extends Command
                 $this->registerConnectorTaskLineOfNextPage($this->source_repository->nextPageQuery());
             }
 
-            if ($this->hasSubset()) {
+            if ($this->source_repository->hasSubset()) {
                 foreach ($this->source_repository->collection() as $entity) {
                     $this->registerConnectorTaskLineOfSubset($entity);
                 }
@@ -308,17 +308,6 @@ class ConnectorTaskLineRunnerCommand extends Command
         }
 
         return $this;
-    }
-
-    protected function hasSubset(): bool
-    {
-        return in_array($this->connector_task_line->source_repository, [
-            ShopifyRestCustomerRepository::class,
-            ShopifyRestOrderRepository::class,
-            ShopifyRestProductRepository::class,
-            ShopifyRestVariantRepository::class,
-            ShopifyRestCollectRepository::class,
-        ]);
     }
 
     protected function createConnectorTaskLine(string $source_repository, array $source_repository_attributes): ConnectorTaskLine

--- a/src/Models/ConnectorTaskLine.php
+++ b/src/Models/ConnectorTaskLine.php
@@ -47,7 +47,9 @@ class ConnectorTaskLine extends Model
     {
         $repository = new $this->source_repository($this->connectorTask->connector->sourceNode);
 
-        $repository->setAttributes($this->source_repository_attributes ?? []);
+        $repository->setStartCursor($this->connectorTask->start_cursor_at)
+            ->setEndCursor($this->connectorTask->end_cursor_at)
+            ->setAttributes($this->source_repository_attributes ?? []);
 
         return $repository;
     }

--- a/src/Models/ConnectorTaskLine.php
+++ b/src/Models/ConnectorTaskLine.php
@@ -45,7 +45,11 @@ class ConnectorTaskLine extends Model
 
     public function buildSourceRepository(): SourceRepository
     {
-        return new $this->source_repository($this->connectorTask->connector->sourceNode);
+        $repository = new $this->source_repository($this->connectorTask->connector->sourceNode);
+
+        $repository->setAttributes($this->source_repository_attributes ?? []);
+
+        return $repository;
     }
 
     public function buildTargetRepository(Collection $collection): TargetRepository

--- a/src/Models/Node/Source/Client/Client.php
+++ b/src/Models/Node/Source/Client/Client.php
@@ -4,5 +4,17 @@ namespace HaruyaNishikubo\Transporter\Models\Node\Source\Client;
 
 abstract class Client
 {
+    protected array $next_page_query = [];
+
     abstract public function get(string $uri, array $query = []): array;
+
+    public function hasNextPage(): bool
+    {
+        return ! empty($this->next_page_query);
+    }
+
+    public function nextPageQuery(): array
+    {
+        return $this->next_page_query;
+    }
 }

--- a/src/Models/Node/Source/Client/Logiless/Client.php
+++ b/src/Models/Node/Source/Client/Logiless/Client.php
@@ -20,8 +20,6 @@ class Client extends BaseClient
 
     protected int $merchant_id;
 
-    protected array $next_page_query = [];
-
     public function __construct(array $attributes = [])
     {
         $this->fill($attributes);
@@ -119,15 +117,5 @@ class Client extends BaseClient
         }
 
         return $this;
-    }
-
-    public function hasNextPage(): bool
-    {
-        return ! empty($this->next_page_query);
-    }
-
-    public function nextPageQuery(): array
-    {
-        return $this->next_page_query;
     }
 }

--- a/src/Models/Node/Source/Client/Shopify/Rest/Client.php
+++ b/src/Models/Node/Source/Client/Shopify/Rest/Client.php
@@ -18,7 +18,6 @@ class Client extends BaseClient
     protected string $api_access_token;
 
     protected Rest $client;
-    protected array $next_page_query = [];
 
     public function __construct(array $attributes = [])
     {
@@ -82,22 +81,12 @@ class Client extends BaseClient
         return $response->getDecodedBody();
     }
 
-    protected function setNextPageQuery(PageInfo $page_info): static
+    protected function setNextPageQuery(?PageInfo $page_info): static
     {
         if (! empty($page_info)) {
             $this->next_page_query = $page_info->getNextPageQuery();
         }
 
         return $this;
-    }
-
-    public function hasNextPage(): bool
-    {
-        return ! empty($this->next_page_query);
-    }
-
-    public function nextPageQuery(): array
-    {
-        return $this->next_page_query;
     }
 }

--- a/src/Models/Node/Source/Client/Shopify/Rest/Client.php
+++ b/src/Models/Node/Source/Client/Shopify/Rest/Client.php
@@ -4,6 +4,7 @@ namespace HaruyaNishikubo\Transporter\Models\Node\Source\Client\Shopify\Rest;
 
 use HaruyaNishikubo\Transporter\Models\Node\Source\Client\Client as BaseClient;
 use Shopify\Auth\FileSessionStorage;
+use Shopify\Clients\PageInfo;
 use Shopify\Clients\Rest;
 use Shopify\Context;
 
@@ -17,6 +18,7 @@ class Client extends BaseClient
     protected string $api_access_token;
 
     protected Rest $client;
+    protected array $next_page_query = [];
 
     public function __construct(array $attributes = [])
     {
@@ -75,6 +77,27 @@ class Client extends BaseClient
         $response = $this->client
             ->get($uri, [], $query);
 
+        $this->setNextPageQuery($response->getPageInfo());
+
         return $response->getDecodedBody();
+    }
+
+    protected function setNextPageQuery(PageInfo $page_info): static
+    {
+        if (! empty($page_info)) {
+            $this->next_page_query = $page_info->getNextPageQuery();
+        }
+
+        return $this;
+    }
+
+    public function hasNextPage(): bool
+    {
+        return ! empty($this->next_page_query);
+    }
+
+    public function nextPageQuery(): array
+    {
+        return $this->next_page_query;
     }
 }

--- a/src/Models/Node/Source/Client/Shopify/Rest/Client.php
+++ b/src/Models/Node/Source/Client/Shopify/Rest/Client.php
@@ -83,7 +83,7 @@ class Client extends BaseClient
 
     protected function setNextPageQuery(?PageInfo $page_info): static
     {
-        if (! empty($page_info)) {
+        if (! empty($page_info) && $page_info->hasNextPage()) {
             $this->next_page_query = $page_info->getNextPageQuery();
         }
 

--- a/src/Models/Node/Source/Repository/Logiless/Repository.php
+++ b/src/Models/Node/Source/Repository/Logiless/Repository.php
@@ -80,4 +80,15 @@ abstract class Repository extends BaseRepository
 
         return $this;
     }
+
+    public function setAttributes(array $attributes): static
+    {
+        parent::setAttributes($attributes);
+
+        if (isset($attributes['query'])) {
+            $this->query = array_merge($this->query, $attributes['query']);
+        }
+
+        return $this;
+    }
 }

--- a/src/Models/Node/Source/Repository/Logiless/Repository.php
+++ b/src/Models/Node/Source/Repository/Logiless/Repository.php
@@ -36,15 +36,6 @@ abstract class Repository extends BaseRepository
         $this->collection = $this->collection
             ->merge($response['data']);
 
-        $next_page = $this->nextPage($response);
-        if (! empty($next_page)) {
-            $this->mergeQuery([
-                'page' => $next_page,
-            ]);
-
-            $this->extract();
-        }
-
         return $this;
     }
 
@@ -76,9 +67,16 @@ abstract class Repository extends BaseRepository
         return $response['current_page'] + 1;
     }
 
-    protected function mergeQuery(array $query): static
+    protected function setNextQueries(array $response): static
     {
-        $this->query = array_merge($this->query, $query);
+        $next_page = $this->nextPage($response);
+        if (empty($next_page)) {
+            return $this;
+        }
+
+        $this->next_queries = array_merge($this->query, [
+            'page' => $next_page,
+        ]);
 
         return $this;
     }

--- a/src/Models/Node/Source/Repository/Logiless/Repository.php
+++ b/src/Models/Node/Source/Repository/Logiless/Repository.php
@@ -49,34 +49,17 @@ abstract class Repository extends BaseRepository
             ],
         ]);
 
+        $this->setNextPageQuery();
+
         return $this->client
             ->get($this->listUrl(), $this->query);
     }
 
-    protected function nextPage(array $response): ?int
+    protected function setNextPageQuery(): static
     {
-        if ($response['total_count'] <= $response['limit']) {
-            return null;
+        if ($this->client->hasNextPage()) {
+            $this->next_page_query = array_merge($this->query, $this->client->nextPageQuery());
         }
-
-        $last_page = (int) ceil($response['total_count'] / $response['limit']);
-        if ($last_page == $response['current_page']) {
-            return null;
-        }
-
-        return $response['current_page'] + 1;
-    }
-
-    protected function setNextQueries(array $response): static
-    {
-        $next_page = $this->nextPage($response);
-        if (empty($next_page)) {
-            return $this;
-        }
-
-        $this->next_queries = array_merge($this->query, [
-            'page' => $next_page,
-        ]);
 
         return $this;
     }

--- a/src/Models/Node/Source/Repository/Repository.php
+++ b/src/Models/Node/Source/Repository/Repository.php
@@ -15,7 +15,7 @@ abstract class Repository
     protected string $end_cursor;
     protected array $query = [];
     protected array $logs = [];
-    protected array $next_queries = [];
+    protected array $next_page_query = [];
 
     abstract public function __construct(Node $node);
 
@@ -25,7 +25,7 @@ abstract class Repository
 
     abstract public function extract(): static;
 
-    abstract protected function setNextQueries(array $response): static;
+    abstract protected function setNextPageQuery(): static;
 
     public function collection(): Collection
     {
@@ -68,13 +68,13 @@ abstract class Repository
         return $this->logs;
     }
 
-    public function nextQueries(): array
+    public function nextPageQuery(): array
     {
-        return $this->next_queries;
+        return $this->next_page_query;
     }
 
-    public function hasNextQueries(): bool
+    public function hasNextPage(): bool
     {
-        return ! empty($this->next_queries);
+        return ! empty($this->next_page_query);
     }
 }

--- a/src/Models/Node/Source/Repository/Repository.php
+++ b/src/Models/Node/Source/Repository/Repository.php
@@ -77,4 +77,9 @@ abstract class Repository
     {
         return ! empty($this->next_page_query);
     }
+
+    public function hasSubset(): bool
+    {
+        return false;
+    }
 }

--- a/src/Models/Node/Source/Repository/Repository.php
+++ b/src/Models/Node/Source/Repository/Repository.php
@@ -13,6 +13,7 @@ abstract class Repository
     protected Collection $collection;
     protected string $start_cursor;
     protected string $end_cursor;
+    protected array $query = [];
     protected array $logs = [];
     protected array $next_queries = [];
 
@@ -48,6 +49,11 @@ abstract class Repository
     public function setAttributes(array $attributes): static
     {
         return $this;
+    }
+
+    public function query(): array
+    {
+        return $this->query;
     }
 
     protected function appendLogs(array $logs): static

--- a/src/Models/Node/Source/Repository/Repository.php
+++ b/src/Models/Node/Source/Repository/Repository.php
@@ -14,6 +14,7 @@ abstract class Repository
     protected string $start_cursor;
     protected string $end_cursor;
     protected array $logs = [];
+    protected array $next_queries = [];
 
     abstract public function __construct(Node $node);
 
@@ -22,6 +23,8 @@ abstract class Repository
     abstract public function prepare(): static;
 
     abstract public function extract(): static;
+
+    abstract protected function setNextQueries(array $response): static;
 
     public function collection(): Collection
     {
@@ -57,5 +60,15 @@ abstract class Repository
     public function logs(): array
     {
         return $this->logs;
+    }
+
+    public function nextQueries(): array
+    {
+        return $this->next_queries;
+    }
+
+    public function hasNextQueries(): bool
+    {
+        return ! empty($this->next_queries);
     }
 }

--- a/src/Models/Node/Source/Repository/Shopify/Rest/CollectRepository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/CollectRepository.php
@@ -23,4 +23,9 @@ class CollectRepository extends Repository
     {
         return 'collects';
     }
+
+    public function hasSubset(): bool
+    {
+        return true;
+    }
 }

--- a/src/Models/Node/Source/Repository/Shopify/Rest/CollectionRepository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/CollectionRepository.php
@@ -28,6 +28,8 @@ class CollectionRepository extends Repository
 
     public function setAttributes(array $attributes): static
     {
+        parent::setAttributes($attributes);
+
         $this->collection_id = $attributes['collection_id'];
 
         return $this;

--- a/src/Models/Node/Source/Repository/Shopify/Rest/CustomerRepository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/CustomerRepository.php
@@ -35,4 +35,9 @@ class CustomerRepository extends Repository
     {
         return 'customers';
     }
+
+    public function hasSubset(): bool
+    {
+        return true;
+    }
 }

--- a/src/Models/Node/Source/Repository/Shopify/Rest/FulfillmentOrderRepository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/FulfillmentOrderRepository.php
@@ -28,6 +28,8 @@ class FulfillmentOrderRepository extends Repository
 
     public function setAttributes(array $attributes): static
     {
+        parent::setAttributes($attributes);
+
         $this->order_id = $attributes['order_id'];
 
         return $this;

--- a/src/Models/Node/Source/Repository/Shopify/Rest/FulfillmentRepository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/FulfillmentRepository.php
@@ -28,6 +28,8 @@ class FulfillmentRepository extends Repository
 
     public function setAttributes(array $attributes): static
     {
+        parent::setAttributes($attributes);
+
         $this->order_id = $attributes['order_id'];
 
         return $this;

--- a/src/Models/Node/Source/Repository/Shopify/Rest/InventoryItemRepository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/InventoryItemRepository.php
@@ -28,6 +28,8 @@ class InventoryItemRepository extends Repository
 
     public function setAttributes(array $attributes): static
     {
+        parent::setAttributes($attributes);
+
         $this->inventory_item_id = $attributes['inventory_item_id'];
 
         return $this;

--- a/src/Models/Node/Source/Repository/Shopify/Rest/MetafieldRepository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/MetafieldRepository.php
@@ -29,6 +29,8 @@ class MetafieldRepository extends Repository
 
     public function setAttributes(array $attributes): static
     {
+        parent::setAttributes($attributes);
+
         $this->owner_resource = $attributes['owner_resource'];
         $this->owner_id = $attributes['owner_id'];
 

--- a/src/Models/Node/Source/Repository/Shopify/Rest/OrderRepository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/OrderRepository.php
@@ -35,4 +35,9 @@ class OrderRepository extends Repository
     {
         return 'orders';
     }
+
+    public function hasSubset(): bool
+    {
+        return true;
+    }
 }

--- a/src/Models/Node/Source/Repository/Shopify/Rest/ProductRepository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/ProductRepository.php
@@ -35,4 +35,9 @@ class ProductRepository extends Repository
     {
         return 'products';
     }
+
+    public function hasSubset(): bool
+    {
+        return true;
+    }
 }

--- a/src/Models/Node/Source/Repository/Shopify/Rest/RefundRepository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/RefundRepository.php
@@ -28,6 +28,8 @@ class RefundRepository extends Repository
 
     public function setAttributes(array $attributes): static
     {
+        parent::setAttributes($attributes);
+
         $this->order_id = $attributes['order_id'];
 
         return $this;

--- a/src/Models/Node/Source/Repository/Shopify/Rest/Repository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/Repository.php
@@ -42,6 +42,8 @@ abstract class Repository extends BaseRepository
 
     protected function getList(): array
     {
+        $this->modifyQueryIfPageInfoExists();
+
         $this->appendLogs([
             'label' => __FUNCTION__,
             'message' => [
@@ -73,6 +75,18 @@ abstract class Repository extends BaseRepository
 
         if (isset($attributes['query'])) {
             $this->query = array_merge($this->query, $attributes['query']);
+        }
+
+        return $this;
+    }
+
+    protected function modifyQueryIfPageInfoExists(): static
+    {
+        if (isset($this->query['page_info'])) {
+            unset(
+                $this->query['updated_at_min'],
+                $this->query['updated_at_max']
+            );
         }
 
         return $this;

--- a/src/Models/Node/Source/Repository/Shopify/Rest/Repository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/Repository.php
@@ -64,7 +64,7 @@ abstract class Repository extends BaseRepository
             return null;
         }
 
-        return $response[self::LIMIT - 1]['id'];
+        return array_reduce($response, fn($carry, $item) => max($item['id'], $carry), 0);
     }
 
     protected function setNextQueries(array $response): static

--- a/src/Models/Node/Source/Repository/Shopify/Rest/Repository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/Repository.php
@@ -80,4 +80,15 @@ abstract class Repository extends BaseRepository
 
         return $this;
     }
+
+    public function setAttributes(array $attributes): static
+    {
+        parent::setAttributes($attributes);
+
+        if (isset($attributes['query'])) {
+            $this->query = array_merge($this->query, $attributes['query']);
+        }
+
+        return $this;
+    }
 }

--- a/src/Models/Node/Source/Repository/Shopify/Rest/Repository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/Repository.php
@@ -37,14 +37,7 @@ abstract class Repository extends BaseRepository
         $this->collection = $this->collection
             ->merge($response);
 
-        $since_id = $this->nextSinceId($response);
-        if (! empty($since_id)) {
-            $this->mergeQuery([
-                'since_id' => $since_id,
-            ]);
-
-            $this->extract();
-        }
+        $this->setNextQueries($response);
 
         return $this;
     }
@@ -74,9 +67,16 @@ abstract class Repository extends BaseRepository
         return $response[self::LIMIT - 1]['id'];
     }
 
-    protected function mergeQuery(array $query): static
+    protected function setNextQueries(array $response): static
     {
-        $this->query = array_merge($this->query, $query);
+        $since_id = $this->nextSinceId($response);
+        if (empty($since_id)) {
+            return $this;
+        }
+
+        $this->next_queries = array_merge($this->query, [
+            'since_id' => $since_id,
+        ]);
 
         return $this;
     }

--- a/src/Models/Node/Source/Repository/Shopify/Rest/TransactionRepository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/TransactionRepository.php
@@ -28,6 +28,8 @@ class TransactionRepository extends Repository
 
     public function setAttributes(array $attributes): static
     {
+        parent::setAttributes($attributes);
+
         $this->order_id = $attributes['order_id'];
 
         return $this;

--- a/src/Models/Node/Source/Repository/Shopify/Rest/VariantRepository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/VariantRepository.php
@@ -34,4 +34,9 @@ class VariantRepository extends Repository
 
         return $this;
     }
+
+    public function hasSubset(): bool
+    {
+        return true;
+    }
 }

--- a/src/Models/Node/Source/Repository/Shopify/Rest/VariantRepository.php
+++ b/src/Models/Node/Source/Repository/Shopify/Rest/VariantRepository.php
@@ -28,6 +28,8 @@ class VariantRepository extends Repository
 
     public function setAttributes(array $attributes): static
     {
+        parent::setAttributes($attributes);
+
         $this->product_id = $attributes['product_id'];
 
         return $this;


### PR DESCRIPTION
# 概要
- transporter:connector-task-line-runner 実行時に該当範囲のデータをすべて取得していたが、データ量が増えると対応できないので、一回の実行では１ページのみとして、２ページ目以降は新しく connector_task_line を作成するように修正